### PR TITLE
REFECTOR-SETTLEMENT / 가독성과 유지보수성 높은 구조로 변경

### DIFF
--- a/src/test/java/com/batch/BatchApplicationTests.java
+++ b/src/test/java/com/batch/BatchApplicationTests.java
@@ -47,7 +47,7 @@ class BatchApplicationTests {
     public void job_test() throws Exception {
 
         //given
-        setDate();
+        setDateSales();
         JobParameters jobParameters = new JobParametersBuilder()
             .addString("job.name", "SettlementJob v=1")
             .toJobParameters();
@@ -56,7 +56,7 @@ class BatchApplicationTests {
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
         //then
-        Assert.assertEquals(jobExecution.getStatus(), BatchStatus.COMPLETED);
+        Assert.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 
         List<DailySettlement> list = dailySettlementRepository.findAll();
         Assert.assertEquals(2, list.size());
@@ -65,7 +65,7 @@ class BatchApplicationTests {
     }
 
 
-    private void setDate() {
+    private void setDateSales() {
 
         Seller seller1 = sellerRepository.save(Seller.builder().build());
         Seller seller2 = sellerRepository.save(Seller.builder().build());


### PR DESCRIPTION
Background
---
기존에는 영속성컨텍스트를 활용해서 매출액을 업데이트 하였다. 그러나 이 방식은 청크지향 배치프로그램에서 권장하는 read-process-writer 구조를 어기고 있었다.  그 이유는 다음과 같다.

> processor에서 직접 dailySettlementRepository를 사용하여 데이터를 읽고, insert or update 저장하고 있었다. 아무리 생각해도 processor에서 할 일이 아니다.

원래 계획은 더티체킹을 이용해서 insert or update할 생각이었다. 그런데 왜 직접 processor에서 save 해야 했는가? 그 이유는 flush가 일어나는 시점이, 한 chunk가 끝날 때가 아니라 JpaItemReader에서 doRead()를 할 때이기 때문이다! 따라서 더티체킹 사용해서 업데이트 한다면, 마지막 chunk에서 데이터 불일치가 일어난다.

Change
---
다음과 같은 구조로 수정했다.
1. SettlementJob 클래스는 멤버 변수로 HashMap<Seller, Long> sellerRevenueMap 를 가진다. 판매자별 일일매출액을 의미한다.
2. 두 step으로 나눈다. step1 에서는 OrderProduct의 status를 정산완료 상태로 바꾸고, 금액을 map에 insert or update 한다.
3. step2에서 sellerRevenueMap를 사용하여 DailySettlement를 DB에 저장한다. step2는 save만 하고 있는 간단한 작업이므로 tasklet으로 구현했다.

Test
---
junit 테스트 완료

Analatics
---
지금 구조로는 병렬처리를 할 수 없다. 병렬처리를 하기 위해서는 추가적인 고민이 필요할 것 같다.
